### PR TITLE
RandomizedTesting.Generators.RandomExtensions: Cascade calls to J2N.Randomizer

### DIFF
--- a/src/RandomizedTesting.Generators/Support/RandomExtensions.cs
+++ b/src/RandomizedTesting.Generators/Support/RandomExtensions.cs
@@ -15,7 +15,7 @@ namespace RandomizedTesting.Generators
     /// </summary>
     public static class RandomExtensions
     {
-        private class RandomProperties
+        private sealed class RandomProperties
         {
             /// <summary>
             /// The boolean value indicating if the second Gaussian number is available.
@@ -44,6 +44,9 @@ namespace RandomizedTesting.Generators
         {
             if (random is null)
                 throw new ArgumentNullException(nameof(random));
+
+            if (random is Randomizer randomizer)
+                return randomizer.NextGaussian();
 
             var props = randomCache.GetOrCreateValue(random);
 
@@ -83,6 +86,9 @@ namespace RandomizedTesting.Generators
             if (random is null)
                 throw new ArgumentNullException(nameof(random));
 
+            if (random is Randomizer randomizer)
+                return randomizer.NextBoolean();
+
             return random.Next(1, 100) > 50;
         }
 
@@ -114,6 +120,9 @@ namespace RandomizedTesting.Generators
         {
             if (random is null)
                 throw new ArgumentNullException(nameof(random));
+
+            if (random is Randomizer randomizer)
+                return randomizer.NextInt64();
 
             byte[] buffer = new byte[8];
             random.NextBytes(buffer);
@@ -161,6 +170,9 @@ namespace RandomizedTesting.Generators
         {
             if (random is null)
                 throw new ArgumentNullException(nameof(random));
+
+            if (random is Randomizer randomizer)
+                return randomizer.NextSingle();
 
             return (float)random.NextDouble(); // always between 0.0 and 1.0, so it will always cast
         }

--- a/tests/RandomizedTesting.Generators.Tests/Support/TestRandomExtensions.cs
+++ b/tests/RandomizedTesting.Generators.Tests/Support/TestRandomExtensions.cs
@@ -1,9 +1,6 @@
 ﻿using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace RandomizedTesting.Generators
 {
@@ -114,6 +111,78 @@ namespace RandomizedTesting.Generators
             }
             Assert.IsTrue(someDifferent, "Calling nextGaussian 100 times resulted in same number");
             Assert.IsTrue(someInsideStd, "Calling nextGaussian 100 times resulted in no number within 1 std. deviation of mean");
+        }
+
+        [Test]
+        public void TestNextInt64AgainstJ2NRandomizer()
+        {
+            long expected;
+            long actual;
+            long seed = new Random().NextInt64();
+
+            J2N.Randomizer randomizer = new J2N.Randomizer(seed);
+            Random random = new J2N.Randomizer(seed);
+
+            for (long i = 0; i < 100; i++)
+            {
+                expected = randomizer.NextInt64();
+                actual = random.NextInt64();
+                Assert.IsTrue(expected == actual);
+            }
+        }
+
+        [Test]
+        public void TestNextSingleAgainstJ2NRandomizer()
+        {
+            float expected;
+            float actual;
+            long seed = new Random().NextInt64();
+
+            J2N.Randomizer randomizer = new J2N.Randomizer(seed);
+            Random random = new J2N.Randomizer(seed);
+
+            for (long i = 0; i < 100; i++)
+            {
+                expected = randomizer.NextSingle();
+                actual = random.NextSingle();
+                Assert.IsTrue(expected == actual);
+            }
+        }
+
+        [Test]
+        public void TestNextBooleanAgainstJ2NRandomizer()
+        {
+            bool expected;
+            bool actual;
+            long seed = new Random().NextInt64();
+
+            J2N.Randomizer randomizer = new J2N.Randomizer(seed);
+            Random random = new J2N.Randomizer(seed);
+
+            for (long i = 0; i < 100; i++)
+            {
+                expected = randomizer.NextBoolean();
+                actual = random.NextBoolean();
+                Assert.IsTrue(expected == actual);
+            }
+        }
+
+        [Test]
+        public void TestNextGaussianAgainstJ2NRandomizer()
+        {
+            double expected;
+            double actual;
+            long seed = new Random().NextInt64();
+
+            J2N.Randomizer randomizer = new J2N.Randomizer(seed);
+            Random random = new J2N.Randomizer(seed);
+
+            for (long i = 0; i < 100; i++)
+            {
+                expected = randomizer.NextGaussian();
+                actual = random.NextGaussian();
+                Assert.IsTrue(expected == actual);
+            }
         }
 
         /**


### PR DESCRIPTION
If the underlying type is `J2N.Randomizer`, cascade the call for `NextInt64()`, `NextSingle()`, `NextGaussian()`, and `NextBoolean()`