### PR TITLE
Feature: Use stack allocations for string buffers when building random strings

### DIFF
--- a/.build/dependencies.props
+++ b/.build/dependencies.props
@@ -9,5 +9,6 @@
     <NETStandardLibrary20PackageReferenceVersion>2.0.3</NETStandardLibrary20PackageReferenceVersion>
     <NUnitPackageReferenceVersion>3.12.0</NUnitPackageReferenceVersion>
     <NUnit3TestAdapterPackageReferenceVersion>3.15.1</NUnit3TestAdapterPackageReferenceVersion>
+    <SystemMemoryPackageReferenceVersion>4.5.5</SystemMemoryPackageReferenceVersion>
   </PropertyGroup>
 </Project>

--- a/src/RandomizedTesting.Generators/RandomizedTesting.Generators.csproj
+++ b/src/RandomizedTesting.Generators/RandomizedTesting.Generators.csproj
@@ -23,6 +23,7 @@
     
   <ItemGroup>
     <PackageReference Include="J2N" Version="$(J2NPackageReferenceVersion)" />
+    <PackageReference Include="System.Memory" Version="$(SystemMemoryPackageReferenceVersion)" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/RandomizedTesting.Generators/RealisticUnicodeGenerator.cs
+++ b/src/RandomizedTesting.Generators/RealisticUnicodeGenerator.cs
@@ -83,7 +83,10 @@ namespace RandomizedTesting.Generators
             int length = RandomNumbers.RandomInt32Between(random, minCodeUnits, maxCodeUnits);
             int block = random.Next(blockStarts.Length);
 
-            StringBuilder sb = new StringBuilder();
+            // RandomizedTesting.Generators: Use ValueStringBuilder to minimize allocations
+            using var sb = length <= CharStackBufferSize
+                ? new ValueStringBuilder(stackalloc char[length])
+                : new ValueStringBuilder(length);
             while (length > 0)
             {
                 int cp = RandomNumbers.RandomInt32Between(random, blockStarts[block], blockEnds[block]);
@@ -116,7 +119,10 @@ namespace RandomizedTesting.Generators
 
             int length = RandomNumbers.RandomInt32Between(random, minCodePoints, maxCodePoints);
             int block = random.Next(blockStarts.Length);
-            StringBuilder sb = new StringBuilder();
+            // RandomizedTesting.Generators: Use ValueStringBuilder to minimize allocations
+            using var sb = length <= CharStackBufferSize
+                ? new ValueStringBuilder(stackalloc char[length])
+                : new ValueStringBuilder(length);
             for (int i = 0; i < length; i++)
                 sb.AppendCodePoint(RandomNumbers.RandomInt32Between(random, blockStarts[block], blockEnds[block]));
             return sb.ToString();

--- a/src/RandomizedTesting.Generators/StringGenerator.cs
+++ b/src/RandomizedTesting.Generators/StringGenerator.cs
@@ -8,6 +8,8 @@ namespace RandomizedTesting.Generators
     /// </summary>
     public abstract class StringGenerator
     {
+        protected const int CharStackBufferSize = 64;
+
         /// <summary>
         /// An alias for <see cref="OfCodeUnitsLength(Random, int, int)"/>.
         /// </summary>

--- a/src/RandomizedTesting.Generators/Support/ValueStringBuilder.AppendRandom.cs
+++ b/src/RandomizedTesting.Generators/Support/ValueStringBuilder.AppendRandom.cs
@@ -1,0 +1,102 @@
+﻿using J2N;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+
+namespace RandomizedTesting.Generators
+{
+    internal ref partial struct ValueStringBuilder
+    {
+        public void AppendNextSimpleString(Random random)
+            => AppendNextSimpleString(random, minLength: 0, maxLength: 10);
+
+        public void AppendNextSimpleString(Random random, int maxLength)
+            => AppendNextSimpleString(random, minLength: 0, maxLength);
+
+        public void AppendNextSimpleString(Random random, int minLength, int maxLength)
+        {
+            Debug.Assert(random != null);
+
+            int end = RandomNumbers.RandomInt32Between(random!, minLength, maxLength);
+            if (end == 0) return; // allow 0 length
+            AppendNextSimpleStringInternal(random!, end);
+        }
+
+        internal void AppendNextSimpleStringInternal(Random random, int end)
+        {
+            Debug.Assert(random != null);
+
+            for (int i = 0; i < end; i++)
+            {
+                Append((char)RandomNumbers.RandomInt32Between(random!, 'a', 'z'));
+            }
+        }
+
+        public void AppendNextStringRecasing(Random random, string value)
+            => AppendNextStringRecasing(random, value, CultureInfo.CurrentCulture);
+
+        public void AppendNextStringRecasing(Random random, string value, CultureInfo culture)
+        {
+            Debug.Assert(random != null);
+            Debug.Assert(value != null);
+
+            int pos = 0;
+            while (pos < value!.Length)
+            {
+                int codePoint = value.CodePointAt(pos);
+                pos += Character.CharCount(codePoint);
+                switch (RandomNumbers.RandomInt32Between(random!, 0, 2))
+                {
+                    case 0:
+                        AppendCodePoint(Character.ToUpper(codePoint, culture));
+                        break;
+                    case 1:
+                        AppendCodePoint(Character.ToLower(codePoint, culture));
+                        break;
+                    case 2:
+                        AppendCodePoint(codePoint); // leave intact
+                        break;
+                }
+            }
+        }
+
+        public void AppendNextFixedLengthUnicodeString(Random random, int length)
+        {
+            int i = 0;
+            while (i < length)
+            {
+                int t = random.Next(5);
+                if (0 == t && i < length - 1)
+                {
+                    // Make a surrogate pair
+                    // High surrogate
+                    Append((char)RandomNumbers.RandomInt32Between(random, 0xd800, 0xdbff));
+                    i++;
+                    // Low surrogate
+                    Append((char)RandomNumbers.RandomInt32Between(random, 0xdc00, 0xdfff));
+                    i++;
+                }
+                else if (t <= 1)
+                {
+                    Append((char)random.Next(0x80));
+                    i++;
+                }
+                else if (2 == t)
+                {
+                    Append((char)RandomNumbers.RandomInt32Between(random, 0x80, 0x7ff));
+                    i++;
+                }
+                else if (3 == t)
+                {
+                    Append((char)RandomNumbers.RandomInt32Between(random, 0x800, 0xd7ff));
+                    i++;
+                }
+                else if (4 == t)
+                {
+                    Append((char)RandomNumbers.RandomInt32Between(random, 0xe000, 0xffff));
+                    i++;
+                }
+            }
+        }
+    }
+}

--- a/src/RandomizedTesting.Generators/Support/ValueStringBuilder.cs
+++ b/src/RandomizedTesting.Generators/Support/ValueStringBuilder.cs
@@ -287,6 +287,25 @@ namespace RandomizedTesting.Generators
             _pos += value.Length;
         }
 
+        public void AppendCodePoint(int codePoint)
+        {
+            Debug.Assert(J2N.Character.IsValidCodePoint(codePoint));
+
+            // From J2N.Character.ToChars()
+            if (J2N.Character.IsSupplementaryCodePoint(codePoint))
+            {
+                int cpPrime = codePoint - 0x10000;
+                int high = 0xD800 | ((cpPrime >> 10) & 0x3FF);
+                int low = 0xDC00 | (cpPrime & 0x3FF);
+                Append((char)high);
+                Append((char)low);
+            }
+            else
+            {
+                Append((char)codePoint);
+            }
+        }
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Span<char> AppendSpan(int length)
         {

--- a/src/RandomizedTesting.Generators/Support/ValueStringBuilder.cs
+++ b/src/RandomizedTesting.Generators/Support/ValueStringBuilder.cs
@@ -1,0 +1,357 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace RandomizedTesting.Generators
+{
+    internal ref partial struct ValueStringBuilder
+    {
+        private char[]? _arrayToReturnToPool;
+        private Span<char> _chars;
+        private int _pos;
+
+        public ValueStringBuilder(Span<char> initialBuffer)
+        {
+            _arrayToReturnToPool = null;
+            _chars = initialBuffer;
+            _pos = 0;
+        }
+
+        public ValueStringBuilder(int initialCapacity)
+        {
+            _arrayToReturnToPool = ArrayPool<char>.Shared.Rent(initialCapacity);
+            _chars = _arrayToReturnToPool;
+            _pos = 0;
+        }
+
+        public int Length
+        {
+            get => _pos;
+            set
+            {
+                Debug.Assert(value >= 0);
+                Debug.Assert(value <= _chars.Length);
+                _pos = value;
+            }
+        }
+
+        public int Capacity => _chars.Length;
+
+        public void EnsureCapacity(int capacity)
+        {
+            // This is not expected to be called this with negative capacity
+            Debug.Assert(capacity >= 0);
+
+            // If the caller has a bug and calls this with negative capacity, make sure to call Grow to throw an exception.
+            if ((uint)capacity > (uint)_chars.Length)
+                Grow(capacity - _pos);
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// Does not ensure there is a null char after <see cref="Length"/>
+        /// </summary>
+        public ref char GetPinnableReference()
+        {
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        /// <summary>
+        /// Get a pinnable reference to the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ref char GetPinnableReference(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return ref MemoryMarshal.GetReference(_chars);
+        }
+
+        public ref char this[int index]
+        {
+            get
+            {
+                Debug.Assert(index < _pos);
+                return ref _chars[index];
+            }
+        }
+
+        public override string ToString()
+        {
+            string s = _chars.Slice(0, _pos).ToString();
+            Dispose();
+            return s;
+        }
+
+        /// <summary>Returns the underlying storage of the builder.</summary>
+        public Span<char> RawChars => _chars;
+
+        /// <summary>
+        /// Returns a span around the contents of the builder.
+        /// </summary>
+        /// <param name="terminate">Ensures that the builder has a null char after <see cref="Length"/></param>
+        public ReadOnlySpan<char> AsSpan(bool terminate)
+        {
+            if (terminate)
+            {
+                EnsureCapacity(Length + 1);
+                _chars[Length] = '\0';
+            }
+            return _chars.Slice(0, _pos);
+        }
+
+        public ReadOnlySpan<char> AsSpan() => _chars.Slice(0, _pos);
+        public ReadOnlySpan<char> AsSpan(int start) => _chars.Slice(start, _pos - start);
+        public ReadOnlySpan<char> AsSpan(int start, int length) => _chars.Slice(start, length);
+
+        public bool TryCopyTo(Span<char> destination, out int charsWritten)
+        {
+            if (_chars.Slice(0, _pos).TryCopyTo(destination))
+            {
+                charsWritten = _pos;
+                Dispose();
+                return true;
+            }
+            else
+            {
+                charsWritten = 0;
+                Dispose();
+                return false;
+            }
+        }
+
+        public void Insert(int index, char value)
+            => Insert(index, value, count: 1);
+
+        public void Insert(int index, char value, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            _chars.Slice(index, count).Fill(value);
+            _pos += count;
+        }
+
+        public void Insert(int index, string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int count = s.Length;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (_pos > (_chars.Length - count))
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            s
+#if !NETCOREAPP
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
+        public void Insert(int index, ReadOnlySpan<char> s)
+        {
+            int count = s.Length;
+
+            if (count == 0)
+            {
+                return;
+            }
+
+            if (_pos > (_chars.Length - count))
+            {
+                Grow(count);
+            }
+
+            int remaining = _pos - index;
+            _chars.Slice(index, remaining).CopyTo(_chars.Slice(index + count));
+            s.CopyTo(_chars.Slice(index));
+            _pos += count;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(char c)
+        {
+            int pos = _pos;
+            if ((uint)pos < (uint)_chars.Length)
+            {
+                _chars[pos] = c;
+                _pos = pos + 1;
+            }
+            else
+            {
+                GrowAndAppend(c);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Append(string? s)
+        {
+            if (s == null)
+            {
+                return;
+            }
+
+            int pos = _pos;
+            if (s.Length == 1 && (uint)pos < (uint)_chars.Length) // very common case, e.g. appending strings from NumberFormatInfo like separators, percent symbols, etc.
+            {
+                _chars[pos] = s[0];
+                _pos = pos + 1;
+            }
+            else
+            {
+                AppendSlow(s);
+            }
+        }
+
+        private void AppendSlow(string s)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - s.Length)
+            {
+                Grow(s.Length);
+            }
+
+            s
+#if !NETCOREAPP
+                .AsSpan()
+#endif
+                .CopyTo(_chars.Slice(pos));
+            _pos += s.Length;
+        }
+
+        public void Append(char c, int count)
+        {
+            if (_pos > _chars.Length - count)
+            {
+                Grow(count);
+            }
+
+            Span<char> dst = _chars.Slice(_pos, count);
+            for (int i = 0; i < dst.Length; i++)
+            {
+                dst[i] = c;
+            }
+            _pos += count;
+        }
+
+        //public unsafe void Append(char* value, int length)
+        //{
+        //    int pos = _pos;
+        //    if (pos > _chars.Length - length)
+        //    {
+        //        Grow(length);
+        //    }
+
+        //    Span<char> dst = _chars.Slice(_pos, length);
+        //    for (int i = 0; i < dst.Length; i++)
+        //    {
+        //        dst[i] = *value++;
+        //    }
+        //    _pos += length;
+        //}
+
+        public void Append(ReadOnlySpan<char> value)
+        {
+            int pos = _pos;
+            if (pos > _chars.Length - value.Length)
+            {
+                Grow(value.Length);
+            }
+
+            value.CopyTo(_chars.Slice(_pos));
+            _pos += value.Length;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public Span<char> AppendSpan(int length)
+        {
+            int origPos = _pos;
+            if (origPos > _chars.Length - length)
+            {
+                Grow(length);
+            }
+
+            _pos = origPos + length;
+            return _chars.Slice(origPos, length);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void GrowAndAppend(char c)
+        {
+            Grow(1);
+            Append(c);
+        }
+
+        /// <summary>
+        /// Resize the internal buffer either by doubling current buffer size or
+        /// by adding <paramref name="additionalCapacityBeyondPos"/> to
+        /// <see cref="_pos"/> whichever is greater.
+        /// </summary>
+        /// <param name="additionalCapacityBeyondPos">
+        /// Number of chars requested beyond current position.
+        /// </param>
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private void Grow(int additionalCapacityBeyondPos)
+        {
+            Debug.Assert(additionalCapacityBeyondPos > 0);
+            Debug.Assert(_pos > _chars.Length - additionalCapacityBeyondPos, "Grow called incorrectly, no resize is needed.");
+
+            const uint ArrayMaxLength = 0x7FFFFFC7; // same as Array.MaxLength
+
+            // Increase to at least the required size (_pos + additionalCapacityBeyondPos), but try
+            // to double the size if possible, bounding the doubling to not go beyond the max array length.
+            int newCapacity = (int)Math.Max(
+                (uint)(_pos + additionalCapacityBeyondPos),
+                Math.Min((uint)_chars.Length * 2, ArrayMaxLength));
+
+            // Make sure to let Rent throw an exception if the caller has a bug and the desired capacity is negative.
+            // This could also go negative if the actual required length wraps around.
+            char[] poolArray = ArrayPool<char>.Shared.Rent(newCapacity);
+
+            _chars.Slice(0, _pos).CopyTo(poolArray);
+
+            char[]? toReturn = _arrayToReturnToPool;
+            _chars = _arrayToReturnToPool = poolArray;
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void Dispose()
+        {
+            char[]? toReturn = _arrayToReturnToPool;
+            this = default; // for safety, to avoid using pooled array if this instance is erroneously appended to again
+            if (toReturn != null)
+            {
+                ArrayPool<char>.Shared.Return(toReturn);
+            }
+        }
+    }
+}

--- a/tests/RandomizedTesting.Generators.Tests/Support/TestRandomExtensions.cs
+++ b/tests/RandomizedTesting.Generators.Tests/Support/TestRandomExtensions.cs
@@ -114,6 +114,27 @@ namespace RandomizedTesting.Generators
         }
 
         [Test]
+        public void TestNextFixedLengthUnicodeString()
+        {
+            char[] buffer = new char[20];
+            r.NextFixedLengthUnicodeString(buffer, 5, 10);
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.AreEqual((char)0, buffer[0]);
+            }
+            bool hasChar = false;
+            for (int i = 5; i < 15; i++)
+            {
+                hasChar |= (buffer[i] != 0);
+            }
+            Assert.IsTrue(hasChar);
+            for (int i = 15; i < 20; i++)
+            {
+                Assert.AreEqual((char)0, buffer[0]);
+            }
+        }
+
+        [Test]
         public void TestNextInt64AgainstJ2NRandomizer()
         {
             long expected;

--- a/tests/RandomizedTesting.Generators.Tests/Support/TestValueStringBuilder.cs
+++ b/tests/RandomizedTesting.Generators.Tests/Support/TestValueStringBuilder.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using J2N;
+using J2N.Text;
 using NUnit.Framework;
 using System;
 using System.Linq;
@@ -8,7 +10,7 @@ using System.Text;
 
 namespace RandomizedTesting.Generators
 {
-    public class TestValueStringBuilder
+    public class TestValueStringBuilder : RandomizedTest
     {
         [Test]
         public void Ctor_Default_CanAppend()
@@ -100,6 +102,24 @@ namespace RandomizedTesting.Generators
             {
                 sb.Append((char)i, i);
                 vsb.Append((char)i, i);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void AppendCodePoint_CharInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                int codePoint = i % 2 == 0
+                    ? Random.Next(minValue: Character.MinSupplementaryCodePoint, maxValue: Character.MaxCodePoint + 1)
+                    : Random.Next(Character.MinCodePoint, Character.MinSupplementaryCodePoint);
+                sb.AppendCodePoint(codePoint);
+                vsb.AppendCodePoint(codePoint);
             }
 
             Assert.AreEqual(sb.Length, vsb.Length);

--- a/tests/RandomizedTesting.Generators.Tests/Support/TestValueStringBuilder.cs
+++ b/tests/RandomizedTesting.Generators.Tests/Support/TestValueStringBuilder.cs
@@ -1,0 +1,318 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Text;
+
+namespace RandomizedTesting.Generators
+{
+    public class TestValueStringBuilder
+    {
+        [Test]
+        public void Ctor_Default_CanAppend()
+        {
+            var vsb = default(ValueStringBuilder);
+            Assert.AreEqual(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.AreEqual(1, vsb.Length);
+            Assert.AreEqual("a", vsb.ToString());
+        }
+
+        [Test]
+        public void Ctor_Span_CanAppend()
+        {
+            var vsb = new ValueStringBuilder(new char[1]);
+            Assert.AreEqual(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.AreEqual(1, vsb.Length);
+            Assert.AreEqual("a", vsb.ToString());
+        }
+
+        [Test]
+        public void Ctor_InitialCapacity_CanAppend()
+        {
+            var vsb = new ValueStringBuilder(1);
+            Assert.AreEqual(0, vsb.Length);
+
+            vsb.Append('a');
+            Assert.AreEqual(1, vsb.Length);
+            Assert.AreEqual("a", vsb.ToString());
+        }
+
+        [Test]
+        public void Append_Char_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                sb.Append((char)i);
+                vsb.Append((char)i);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void Append_String_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                string s = i.ToString();
+                sb.Append(s);
+                vsb.Append(s);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        [TestCase(0, 4 * 1024 * 1024)]
+        [TestCase(1025, 4 * 1024 * 1024)]
+        [TestCase(3 * 1024 * 1024, 6 * 1024 * 1024)]
+        public void Append_String_Large_MatchesStringBuilder(int initialLength, int stringLength)
+        {
+            var sb = new StringBuilder(initialLength);
+            var vsb = new ValueStringBuilder(new char[initialLength]);
+
+            string s = new string('a', stringLength);
+            sb.Append(s);
+            vsb.Append(s);
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void Append_CharInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            for (int i = 1; i <= 100; i++)
+            {
+                sb.Append((char)i, i);
+                vsb.Append((char)i, i);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        //[Test]
+        //public unsafe void Append_PtrInt_MatchesStringBuilder()
+        //{
+        //    var sb = new StringBuilder();
+        //    var vsb = new ValueStringBuilder();
+        //    for (int i = 1; i <= 100; i++)
+        //    {
+        //        string s = i.ToString();
+        //        fixed (char* p = s)
+        //        {
+        //            sb.Append(p, s.Length);
+        //            vsb.Append(p, s.Length);
+        //        }
+        //    }
+
+        //    Assert.AreEqual(sb.Length, vsb.Length);
+        //    Assert.AreEqual(sb.ToString(), vsb.ToString());
+        //}
+
+        [Test]
+        public void AppendSpan_DataAppendedCorrectly()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+
+            for (int i = 1; i <= 1000; i++)
+            {
+                string s = i.ToString();
+
+                sb.Append(s);
+
+                Span<char> span = vsb.AppendSpan(s.Length);
+                Assert.AreEqual(sb.Length, vsb.Length);
+
+                s.AsSpan().CopyTo(span);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void Insert_IntCharInt_MatchesStringBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+            var rand = new Random(42);
+
+            for (int i = 1; i <= 100; i++)
+            {
+                int index = rand.Next(sb.Length);
+                sb.Insert(index, new string((char)i, 1), i);
+                vsb.Insert(index, (char)i, i);
+            }
+
+            Assert.AreEqual(sb.Length, vsb.Length);
+            Assert.AreEqual(sb.ToString(), vsb.ToString());
+        }
+
+        [Test]
+        public void AsSpan_ReturnsCorrectValue_DoesntClearBuilder()
+        {
+            var sb = new StringBuilder();
+            var vsb = new ValueStringBuilder();
+
+            for (int i = 1; i <= 100; i++)
+            {
+                string s = i.ToString();
+                sb.Append(s);
+                vsb.Append(s);
+            }
+
+            var resultString = vsb.AsSpan().ToString();
+            Assert.AreEqual(sb.ToString(), resultString);
+
+            Assert.AreNotEqual(0, sb.Length);
+            Assert.AreEqual(sb.Length, vsb.Length);
+        }
+
+        [Test]
+        public void ToString_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.AreEqual(Text1.Length, vsb.Length);
+
+            string s = vsb.ToString();
+            Assert.AreEqual(Text1, s);
+
+            Assert.AreEqual(0, vsb.Length);
+            Assert.AreEqual(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.AreEqual(Text2.Length, vsb.Length);
+            Assert.AreEqual(Text2, vsb.ToString());
+        }
+
+        [Test]
+        public void TryCopyTo_FailsWhenDestinationIsTooSmall_SucceedsWhenItsLargeEnough()
+        {
+            var vsb = new ValueStringBuilder();
+
+            const string Text = "expected text";
+            vsb.Append(Text);
+            Assert.AreEqual(Text.Length, vsb.Length);
+
+            Span<char> dst = new char[Text.Length - 1];
+            Assert.False(vsb.TryCopyTo(dst, out int charsWritten));
+            Assert.AreEqual(0, charsWritten);
+            Assert.AreEqual(0, vsb.Length);
+        }
+
+        [Test]
+        public void TryCopyTo_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.AreEqual(Text1.Length, vsb.Length);
+
+            Span<char> dst = new char[Text1.Length];
+            Assert.True(vsb.TryCopyTo(dst, out int charsWritten));
+            Assert.AreEqual(Text1.Length, charsWritten);
+            Assert.AreEqual(Text1, dst.ToString());
+
+            Assert.AreEqual(0, vsb.Length);
+            Assert.AreEqual(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.AreEqual(Text2.Length, vsb.Length);
+            Assert.AreEqual(Text2, vsb.ToString());
+        }
+
+        [Test]
+        public void Dispose_ClearsBuilder_ThenReusable()
+        {
+            const string Text1 = "test";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+            Assert.AreEqual(Text1.Length, vsb.Length);
+
+            vsb.Dispose();
+
+            Assert.AreEqual(0, vsb.Length);
+            Assert.AreEqual(string.Empty, vsb.ToString());
+            Assert.True(vsb.TryCopyTo(Span<char>.Empty, out _));
+
+            const string Text2 = "another test";
+            vsb.Append(Text2);
+            Assert.AreEqual(Text2.Length, vsb.Length);
+            Assert.AreEqual(Text2, vsb.ToString());
+        }
+
+        [Test]
+        public /*unsafe*/ void Indexer()
+        {
+            const string Text1 = "foobar";
+            var vsb = new ValueStringBuilder();
+
+            vsb.Append(Text1);
+
+            Assert.AreEqual('b', vsb[3]);
+            vsb[3] = 'c';
+            Assert.AreEqual('c', vsb[3]);
+        }
+
+        [Test]
+        public void EnsureCapacity_IfRequestedCapacityWins()
+        {
+            // Note: constants used here may be dependent on minimal buffer size
+            // the ArrayPool is able to return.
+            var builder = new ValueStringBuilder(stackalloc char[32]);
+
+            builder.EnsureCapacity(65);
+
+            Assert.AreEqual(128, builder.Capacity);
+        }
+
+        [Test]
+        public void EnsureCapacity_IfBufferTimesTwoWins()
+        {
+            var builder = new ValueStringBuilder(stackalloc char[32]);
+
+            builder.EnsureCapacity(33);
+
+            Assert.AreEqual(64, builder.Capacity);
+        }
+
+        [Test]
+        public void EnsureCapacity_NoAllocIfNotNeeded()
+        {
+            // Note: constants used here may be dependent on minimal buffer size
+            // the ArrayPool is able to return.
+            var builder = new ValueStringBuilder(stackalloc char[64]);
+
+            builder.EnsureCapacity(16);
+
+            Assert.AreEqual(64, builder.Capacity);
+        }
+    }
+
+}


### PR DESCRIPTION
This reworks the string generators to use stack allocations and fall back to the array pool for buffers used while creating random strings.